### PR TITLE
Add jx-demo-sa secret

### DIFF
--- a/env/templates/jx-demo-sa.yaml
+++ b/env/templates/jx-demo-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  jx-demo-sa.key.json: {{ .Values.JenkinsXDemoSA | b64enc | quote }}
+kind: Secret
+metadata:
+  name: jx-demo-sa
+  namespace: jx
+type: Opaque

--- a/env/values.yaml
+++ b/env/values.yaml
@@ -88,6 +88,7 @@ cbNexusToken: vault:gitOps/jenkins-x/environment-tekton-mole-dev/cb-nexus-token:
 cbNexusUsername: vault:gitOps/jenkins-x/environment-tekton-mole-dev/cb-nexus-token:username
 codecovToken: vault:gitOps/jenkins-x/environment-tekton-mole-dev/codecov:token-passthrough
 akmsToken: vault:gitOps/jenkins-x/environment-tekton-mole-dev/amazon-kms-id:token
+JenkinsXDemoSA: vault:gitOps/jenkins-x/environment-tekton-mole-dev/jenkins-x-demo-sa:data
 
 jx-app-prometheus:
   nodeExporter:


### PR DESCRIPTION
In order to run end to end tests for jxui-backend, we need to be able to access the test cluster.