### PR TITLE
fix: Use newer image in pipelinerunner and controllerbuild

### DIFF
--- a/env/prow/values.yaml
+++ b/env/prow/values.yaml
@@ -5,9 +5,9 @@ buildnum:
   enabled: false
 pipelinerunner:
   enabled: "true"
-  # image:
-  #   repository: rawlingsj80/builder-maven
-  #   tag: wip80
+  image:
+    repository: gcr.io/jenkinsxio/builder-maven
+    tag: 0.1.590
 tillerNamespace: ""
 
 sinker:


### PR DESCRIPTION
`jx step create task` and `pipelinerunner` in general has gotten a _lot_ of key fixes in the last two months that aren't in the cluster currently. Let's bump it to a current version. Here are some noteworthy changes we'll pick up in the process:

* Don't panic the `pipelinerunner` for `unadvertised object` errors, since we don't actually care about those.
* Create the `PipelineActivity` before we create the `Pipeline`, `PipelineRun`, etc.
* Populate the right labels onto `Pipeline`s, `PipelineRun`s, etc to make logging smoother.

To be safe, we're picking up the equivalent version for `controllerbuild`, but I don't think that in practice we actually need it. Better safe than sorry, though!

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>